### PR TITLE
Reduce landing page height and update Section5 layout

### DIFF
--- a/src/Components/Home/LandingPage/LandingPage.css
+++ b/src/Components/Home/LandingPage/LandingPage.css
@@ -186,7 +186,7 @@
   .landing-page-container {
     background-size: 400%;
     /* padding: 40% 5% 45% 5%; */
-    height: 100vh;
+    height: 65vh;
     padding: 0 5%;
     width: 90%;
     display: flex;

--- a/src/Components/Home/LandingPage/LandingPage.css
+++ b/src/Components/Home/LandingPage/LandingPage.css
@@ -127,7 +127,7 @@
     flex-direction: column;
     align-items: center;
     background-position: center;
-    height: 100vh;
+    height: 70vh;
   }
 
   .landing-page-container > p {

--- a/src/Components/Home/LandingPage/LandingPage.css
+++ b/src/Components/Home/LandingPage/LandingPage.css
@@ -75,7 +75,7 @@
     flex-direction: column;
     align-items: center;
     background-position: center;
-    height: 100vh;
+    height: 70vh;
   }
 
   .landing-button-container {

--- a/src/Components/Home/LandingPage/LandingPage.css
+++ b/src/Components/Home/LandingPage/LandingPage.css
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100vh;
+  height: 75vh;
   justify-content: center;
 }
 

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -76,7 +76,7 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    gap: 10px;
+    gap: 15px;
   }
 
   .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -66,17 +66,18 @@
     flex-wrap: wrap;
     height: auto;
     align-items: center;
-    justify-content: space-between;
+    justify-content: space-around;
     width: 100%;
+    gap: 8px;
   }
 
   .logo-img {
-    height: 40px;
+    height: 30px;
     width: auto;
     display: block;
     filter: grayscale(100%);
     transition: 200ms;
-    padding: 5%;
+    padding: 3%;
   }
 
   .section5-container > h4 {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -115,12 +115,12 @@
 
   .logo-containers {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     height: auto;
     align-items: center;
     justify-content: space-around;
     width: 100%;
-    gap: 5px;
+    gap: 3px;
   }
 
   .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -21,7 +21,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  gap: 15px;
+  gap: 23px;
 }
 
 .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -112,14 +112,15 @@
     align-items: center;
     justify-content: space-around;
     width: 100%;
+    gap: 5px;
   }
 
   .logo-img {
-    height: 30px;
+    height: 22px;
     width: auto;
     display: block;
     transition: 200ms;
-    padding: 8%;
+    padding: 4%;
   }
 
   .section5-container > h4 {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -1,5 +1,5 @@
 .section5-container {
-  padding: 2% 7%;
+  padding: 1% 7%;
   background: #fcfcfc;
   width: 86%;
   display: flex;

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -55,6 +55,10 @@
   height: 15px !important;
 }
 
+.falling-walls-logo {
+  height: 55px !important;
+}
+
 @media screen and (max-width: 1024px) {
   .section5-container {
     padding: 3% 5%;

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -74,9 +74,9 @@
     flex-wrap: nowrap;
     height: auto;
     align-items: center;
-    justify-content: space-around;
+    justify-content: space-between;
     width: 100%;
-    gap: 6px;
+    gap: 10px;
   }
 
   .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -128,7 +128,7 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    gap: 8px;
+    gap: 12px;
   }
 
   .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -95,7 +95,7 @@
 
 @media screen and (max-width: 500px) {
   .section5-container {
-    padding: 20% 7%;
+    padding: 8% 7%;
     background: #fcfcfc;
     width: 84%;
     display: flex;

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -19,8 +19,9 @@
   flex-wrap: wrap;
   height: auto;
   align-items: center;
-  justify-content: space-between;
+  justify-content: space-around;
   width: 100%;
+  gap: 10px;
 }
 
 .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -25,7 +25,7 @@
 }
 
 .logo-img {
-  height: 30px;
+  height: 25px;
   width: auto;
   display: block;
   filter: grayscale(100%);

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -131,6 +131,10 @@
     padding: 4%;
   }
 
+  .hypebeast-logo {
+    height: 15px !important;
+  }
+
   .section5-container > h4 {
     font-family: "WorkSinMedium";
     margin: 0;

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -126,9 +126,9 @@
     flex-wrap: nowrap;
     height: auto;
     align-items: center;
-    justify-content: space-around;
+    justify-content: space-between;
     width: 100%;
-    gap: 3px;
+    gap: 8px;
   }
 
   .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -97,6 +97,10 @@
   .logo-containers {
     justify-content: space-around;
   }
+
+  .hypebeast-logo {
+    height: 21px !important;
+  }
 }
 
 @media screen and (max-width: 500px) {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -67,12 +67,12 @@
 
   .logo-containers {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     height: auto;
     align-items: center;
     justify-content: space-around;
     width: 100%;
-    gap: 8px;
+    gap: 6px;
   }
 
   .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -19,9 +19,9 @@
   flex-wrap: nowrap;
   height: auto;
   align-items: center;
-  justify-content: space-around;
+  justify-content: space-between;
   width: 100%;
-  gap: 8px;
+  gap: 15px;
 }
 
 .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -105,6 +105,10 @@
   .hypebeast-logo {
     height: 21px !important;
   }
+
+  .falling-walls-logo {
+    height: 45px !important;
+  }
 }
 
 @media screen and (max-width: 500px) {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -51,6 +51,10 @@
   filter: grayscale(0%);
 }
 
+.hypebeast-logo {
+  height: 15px !important;
+}
+
 @media screen and (max-width: 1024px) {
   .section5-container {
     padding: 3% 5%;

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -25,7 +25,7 @@
 }
 
 .logo-img {
-  height: 25px;
+  height: 22px;
   width: auto;
   display: block;
   filter: grayscale(100%);

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -1,5 +1,5 @@
 .section5-container {
-  padding: 1% 7%;
+  padding: 0 7% 1% 7%;
   background: #fcfcfc;
   width: 86%;
   display: flex;

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -16,12 +16,12 @@
 
 .logo-containers {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   height: auto;
   align-items: center;
   justify-content: space-around;
   width: 100%;
-  gap: 10px;
+  gap: 8px;
 }
 
 .logo-img {

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -143,6 +143,10 @@
     height: 15px !important;
   }
 
+  .falling-walls-logo {
+    height: 35px !important;
+  }
+
   .section5-container > h4 {
     font-family: "WorkSinMedium";
     margin: 0;

--- a/src/Components/Home/Section5/Section5.css
+++ b/src/Components/Home/Section5/Section5.css
@@ -52,7 +52,7 @@
 
 @media screen and (max-width: 1024px) {
   .section5-container {
-    padding: 10% 5%;
+    padding: 3% 5%;
     background: #fcfcfc;
     width: 90%;
     display: flex;

--- a/src/Components/Home/Section5/Section5.js
+++ b/src/Components/Home/Section5/Section5.js
@@ -79,7 +79,7 @@ export default class Section5 extends Component {
             className="media-link"
           >
             <img
-              className="logo-img"
+              className="logo-img hypebeast-logo"
               src="https://cdn.builder.io/api/v1/image/assets%2F2891faa92b574a07a8369948a9a1f207%2F3c391b7c18ce46e58b171ad4eaf75cc3?format=webp&width=800"
               alt="Hypebeast article"
             />

--- a/src/Components/Home/Section5/Section5.js
+++ b/src/Components/Home/Section5/Section5.js
@@ -33,16 +33,12 @@ export default class Section5 extends Component {
             <img className="logo-img" src={Ted} alt="TED Talk" />
           </a>
           <a
-            href="https://www.technologyreview.com/2017/08/16/149478/startup-turns-air-pollution-into-ink/"
+            href="https://www.media.mit.edu/posts/airink-wins/"
             target="_blank"
             rel="noopener noreferrer"
             className="media-link"
           >
-            <img
-              className="logo-img"
-              src={Mit}
-              alt="MIT Technology Review article"
-            />
+            <img className="logo-img" src={Mit} alt="MIT SOLVE article" />
           </a>
           <a
             href="https://www.smithsonianmag.com/innovation/startup-captures-air-pollution-turns-it-ink-180967949/"
@@ -63,6 +59,42 @@ export default class Section5 extends Component {
             className="media-link"
           >
             <img className="logo-img" src={Guard} alt="The Guardian article" />
+          </a>
+          <a
+            href="https://www.forbes.com/sites/brookerobertsislam/2021/04/20/pangaias-game-changing-collaboration-draws-carbon-from-air-pollution-to-print-textiles/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="media-link"
+          >
+            <img
+              className="logo-img"
+              src="https://cdn.builder.io/api/v1/image/assets%2F2891faa92b574a07a8369948a9a1f207%2F8f198d5d490f4f378d0a13e5963620f5?format=webp&width=800"
+              alt="Forbes article"
+            />
+          </a>
+          <a
+            href="https://hypebeast.com/2022/10/johnnie-walker-air-ink-collaboration-unboxing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="media-link"
+          >
+            <img
+              className="logo-img"
+              src="https://cdn.builder.io/api/v1/image/assets%2F2891faa92b574a07a8369948a9a1f207%2F3c391b7c18ce46e58b171ad4eaf75cc3?format=webp&width=800"
+              alt="Hypebeast article"
+            />
+          </a>
+          <a
+            href="https://falling-walls.com/foundation/people/graviky-labs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="media-link"
+          >
+            <img
+              className="logo-img"
+              src="https://cdn.builder.io/api/v1/image/assets%2F2891faa92b574a07a8369948a9a1f207%2F3db609537699485d9a07025d4ec8d5ca?format=webp&width=800"
+              alt="Falling Walls Foundation"
+            />
           </a>
         </ScrollAnimation>
       </div>

--- a/src/Components/Home/Section5/Section5.js
+++ b/src/Components/Home/Section5/Section5.js
@@ -91,8 +91,8 @@ export default class Section5 extends Component {
             className="media-link"
           >
             <img
-              className="logo-img"
-              src="https://cdn.builder.io/api/v1/image/assets%2F2891faa92b574a07a8369948a9a1f207%2F3db609537699485d9a07025d4ec8d5ca?format=webp&width=800"
+              className="logo-img falling-walls-logo"
+              src="https://cdn.builder.io/api/v1/image/assets%2F2891faa92b574a07a8369948a9a1f207%2F074314d588d447dc920a98407e46642f"
               alt="Falling Walls Foundation"
             />
           </a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3084,13 +3084,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-bindings@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
-  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
-  dependencies:
-    file-uri-to-path "1.0.0"
-
 bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
@@ -5258,11 +5251,6 @@ file-loader@*, file-loader@4.3.0:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
 
-file-uri-to-path@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
-  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
-
 filesize@6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz"
@@ -5522,24 +5510,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
-
-fsevents@^1.2.7:
-  version "1.2.13"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
-  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
-  dependencies:
-    bindings "^1.5.0"
-    nan "^2.12.1"
-
-fsevents@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz"
-  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
-
-fsevents@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz"
-  integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
 
 fslightbox-react@^1.4.9:
   version "1.4.9"
@@ -7759,11 +7729,6 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
-
-nan@^2.12.1:
-  version "2.14.1"
-  resolved "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz"
-  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -11668,13 +11633,6 @@ warning@^4.0.3:
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
-
-watchpack-chokidar2@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz"
-  integrity sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==
-  dependencies:
-    chokidar "^2.1.8"
 
 watchpack@^1.6.0:
   version "1.7.2"


### PR DESCRIPTION
This pull request makes the following changes:

**Landing Page (LandingPage.css):**
- Reduced container height from 100vh to 75vh on desktop
- Reduced container height from 100vh to 70vh on tablet (1024px breakpoint)
- Reduced container height from 100vh to 70vh on mobile (768px breakpoint)
- Reduced container height from 100vh to 65vh on small mobile (500px breakpoint)

**Section5 (Section5.css & Section5.js):**
- Updated padding from "2% 7%" to "0 7% 1% 7%" on desktop
- Changed logo containers from flex-wrap to nowrap
- Added 23px gap between logo containers on desktop
- Reduced logo image height from 30px to 22px on desktop
- Added specific height overrides for hypebeast-logo (15px) and falling-walls-logo (55px)
- Updated responsive breakpoint styles with similar adjustments
- Added three new media links: Forbes, Hypebeast, and Falling Walls Foundation
- Updated MIT link URL and alt text

**Dependencies (yarn.lock):**
- Removed unused dependencies: bindings, file-uri-to-path, fsevents, nan, and watchpack-chokidar2

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/110ca00090e74cad9fa49b1e5068d30e/glow-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>110ca00090e74cad9fa49b1e5068d30e</projectId>-->
<!--<branchName>glow-haven</branchName>-->