### PR TITLE
Reduce spacing and sizing in CaseStudies component

### DIFF
--- a/src/Components/Home/CaseStudies/CaseStudies.css
+++ b/src/Components/Home/CaseStudies/CaseStudies.css
@@ -380,25 +380,26 @@
 
 @media screen and (max-width: 768px) {
   .case-studies-container {
-    padding: 6% 0;
+    padding: 3% 0;
   }
 
   .case-studies-content {
-    width: 90%;
+    width: 95%;
   }
 
   .case-studies-title {
-    font-size: 2.5rem;
+    font-size: 2.2rem;
+    margin-bottom: 0.8rem;
   }
 
   .case-studies-subtitle {
-    font-size: 1.2rem;
-    margin-bottom: 2rem;
+    font-size: 1.1rem;
+    margin-bottom: 1.5rem;
   }
 
   .case-studies-layout {
     flex-direction: column;
-    gap: 2rem;
+    gap: 1.5rem;
   }
 
   .case-studies-tabs {
@@ -407,46 +408,68 @@
     flex-wrap: wrap;
     min-width: auto;
     flex: none;
+    gap: 0.5rem;
   }
 
   .tab-button {
     width: auto;
-    min-width: 200px;
-    max-width: 300px;
+    min-width: 140px;
+    max-width: 180px;
     text-align: center;
     align-items: center;
+    padding: 0.8rem 1rem;
+    font-size: 0.9rem;
+  }
+
+  .tab-subtitle {
+    font-size: 0.75rem;
   }
 
   .tab-content {
-    padding: 2rem 1.5rem;
+    padding: 1.5rem 1rem;
   }
 
   .case-study-content h3 {
-    font-size: 1.8rem;
+    font-size: 1.6rem;
+    margin-bottom: 0.8rem;
   }
 
   .case-study-content p {
-    font-size: 1.1rem;
+    font-size: 1rem;
+    margin-bottom: 1rem;
   }
 
   .case-study-stats {
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 1rem;
   }
 
   .stat h4 {
-    font-size: 2rem;
+    font-size: 1.8rem;
   }
 
   .materials-gallery {
-    flex-direction: column;
-    align-items: center;
-    gap: 1.5rem;
+    flex-direction: row;
+    justify-content: center;
+    gap: 1rem;
   }
 
   .material-item {
-    max-width: 300px;
+    max-width: 150px;
     width: 100%;
+    padding: 0.8rem;
+  }
+
+  .material-item img {
+    height: 100px;
+  }
+
+  .case-study-visual {
+    margin-bottom: 1rem;
+  }
+
+  .printed-materials {
+    margin: 1rem 0;
   }
 }
 

--- a/src/Components/Home/CaseStudies/CaseStudies.css
+++ b/src/Components/Home/CaseStudies/CaseStudies.css
@@ -1,7 +1,7 @@
 .case-studies-container {
   width: 100%;
   background: #ffffff;
-  padding: 8% 0;
+  padding: 4% 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -32,7 +32,7 @@
 
 .case-studies-layout {
   display: flex;
-  gap: 3rem;
+  gap: 2rem;
   align-items: flex-start;
   max-width: 1200px;
   margin: 0 auto;
@@ -41,9 +41,9 @@
 .case-studies-tabs {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  min-width: 300px;
-  flex: 0 0 300px;
+  gap: 0.8rem;
+  min-width: 280px;
+  flex: 0 0 280px;
 }
 
 .tab-button {
@@ -51,12 +51,12 @@
   border: 2px solid #095ce5;
   color: #095ce5;
   font-family: "JosefinBold";
-  font-size: 1.1rem;
-  padding: 1.5rem 2rem;
-  border-radius: 20px;
+  font-size: 1rem;
+  padding: 1rem 1.5rem;
+  border-radius: 15px;
   cursor: pointer;
   transition: all 300ms ease;
-  min-width: 280px;
+  min-width: 260px;
   text-align: left;
   display: flex;
   flex-direction: column;
@@ -85,25 +85,25 @@
 
 .tab-content {
   background: #f8f9fa;
-  border-radius: 20px;
-  padding: 3rem;
+  border-radius: 15px;
+  padding: 2rem;
   flex: 1;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
 }
 
 .case-study-content h3 {
   font-family: "JosefinBold";
-  font-size: 2.2rem;
+  font-size: 1.8rem;
   color: #202020;
-  margin: 0 0 1.5rem 0;
+  margin: 0 0 1rem 0;
 }
 
 .case-study-content p {
   font-family: "WorkSinRegular";
-  font-size: 1.2rem;
+  font-size: 1.1rem;
   color: #555;
-  line-height: 1.6;
-  margin-bottom: 2rem;
+  line-height: 1.5;
+  margin-bottom: 1.5rem;
 }
 
 .case-study-stats {
@@ -158,7 +158,7 @@
 
 /* Visual Assets Styling */
 .case-study-visual {
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
   text-align: center;
 }
 
@@ -178,23 +178,23 @@
 
 /* Printed Materials Gallery */
 .printed-materials {
-  margin: 2.5rem 0;
+  margin: 1.5rem 0;
   text-align: center;
 }
 
 .printed-materials h4 {
   font-family: "JosefinBold";
-  font-size: 1.8rem;
+  font-size: 1.5rem;
   color: #095ce5;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .materials-gallery {
   display: flex;
   justify-content: center;
-  gap: 2rem;
+  gap: 1.5rem;
   flex-wrap: wrap;
-  margin-top: 1.5rem;
+  margin-top: 1rem;
 }
 
 .material-item {
@@ -220,10 +220,10 @@
 
 .material-item img {
   width: 100%;
-  height: 150px;
+  height: 120px;
   object-fit: cover;
   border-radius: 10px;
-  margin-bottom: 1rem;
+  margin-bottom: 0.8rem;
   transition:
     transform 300ms ease,
     box-shadow 300ms ease;

--- a/src/Components/Home/CaseStudies/CaseStudies.css
+++ b/src/Components/Home/CaseStudies/CaseStudies.css
@@ -358,23 +358,56 @@
 }
 
 /* Responsive Design */
-@media screen and (max-width: 1024px) {
-  .case-studies-title {
-    font-size: 3rem;
+@media screen and (max-width: 1200px) {
+  .case-studies-container {
+    padding: 3% 0;
+  }
+
+  .case-studies-layout {
+    gap: 1.5rem;
   }
 
   .case-studies-tabs {
-    gap: 1rem;
-  }
-
-  .tab-button {
-    min-width: 160px;
-    font-size: 1rem;
-    padding: 0.8rem 1.5rem;
+    min-width: 260px;
+    flex: 0 0 260px;
   }
 
   .tab-content {
-    padding: 2.5rem;
+    padding: 2rem;
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  .case-studies-title {
+    font-size: 2.8rem;
+  }
+
+  .case-studies-layout {
+    gap: 1.5rem;
+  }
+
+  .case-studies-tabs {
+    gap: 0.8rem;
+    min-width: 240px;
+    flex: 0 0 240px;
+  }
+
+  .tab-button {
+    min-width: 220px;
+    font-size: 0.95rem;
+    padding: 1rem 1.2rem;
+  }
+
+  .tab-content {
+    padding: 1.8rem;
+  }
+
+  .case-study-content h3 {
+    font-size: 1.7rem;
+  }
+
+  .case-study-content p {
+    font-size: 1.05rem;
   }
 }
 

--- a/src/Components/Home/CaseStudies/CaseStudies.css
+++ b/src/Components/Home/CaseStudies/CaseStudies.css
@@ -474,29 +474,72 @@
 }
 
 @media screen and (max-width: 500px) {
+  .case-studies-container {
+    padding: 2% 0;
+  }
+
   .case-studies-title {
-    font-size: 2rem;
+    font-size: 1.8rem;
+    margin-bottom: 0.5rem;
   }
 
   .case-studies-subtitle {
-    font-size: 1rem;
+    font-size: 0.95rem;
+    margin-bottom: 1rem;
+  }
+
+  .case-studies-tabs {
+    gap: 0.4rem;
+  }
+
+  .tab-button {
+    min-width: 120px;
+    max-width: 140px;
+    padding: 0.6rem 0.8rem;
+    font-size: 0.85rem;
+  }
+
+  .tab-subtitle {
+    font-size: 0.7rem;
   }
 
   .tab-content {
-    padding: 1.5rem 1rem;
+    padding: 1rem 0.8rem;
   }
 
   .case-study-content h3 {
-    font-size: 1.5rem;
+    font-size: 1.4rem;
+    margin-bottom: 0.6rem;
   }
 
   .case-study-content p {
-    font-size: 1rem;
+    font-size: 0.95rem;
+    margin-bottom: 0.8rem;
   }
 
   .case-study-link {
-    padding: 0.8rem 2rem;
-    font-size: 1rem;
+    padding: 0.7rem 1.5rem;
+    font-size: 0.9rem;
+  }
+
+  .materials-gallery {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.8rem;
+  }
+
+  .material-item {
+    max-width: 200px;
+    padding: 0.6rem;
+  }
+
+  .material-item img {
+    height: 80px;
+  }
+
+  .printed-materials h4 {
+    font-size: 1.2rem;
+    margin-bottom: 0.8rem;
   }
 
   /* Lightbox Mobile Styles */

--- a/src/Components/Home/CaseStudies/CaseStudies.js
+++ b/src/Components/Home/CaseStudies/CaseStudies.js
@@ -137,7 +137,7 @@ export default class CaseStudies extends Component {
                       <ReactPlayer
                         url="https://youtu.be/rqlQd-vfOTk?si=B7E5GT_J1uvyOiUk&t=16"
                         width="100%"
-                        height="300px"
+                        height="250px"
                         controls={true}
                         className="case-study-video"
                       />
@@ -186,7 +186,7 @@ export default class CaseStudies extends Component {
                       <ReactPlayer
                         url="https://www.youtube.com/watch?v=LRZedVsNulk"
                         width="100%"
-                        height="300px"
+                        height="250px"
                         controls={true}
                         className="case-study-video"
                       />
@@ -247,7 +247,7 @@ export default class CaseStudies extends Component {
                       <ReactPlayer
                         url="https://www.youtube.com/watch?v=YSSW5uqsEoc"
                         width="100%"
-                        height="300px"
+                        height="250px"
                         controls={true}
                         className="case-study-video"
                       />


### PR DESCRIPTION
This pull request reduces spacing and sizing throughout the CaseStudies component to create a more compact layout.

Changes include:
- Reduced container padding from 8% to 4%
- Decreased gaps between layout elements (3rem to 2rem, 1rem to 0.8rem)
- Reduced tab button dimensions and padding
- Decreased border radius from 20px to 15px
- Reduced font sizes across headings and text
- Lowered video player height from 300px to 250px
- Adjusted margins and padding throughout the component
- Enhanced responsive design with additional breakpoints and more compact mobile layouts
- Updated box shadow values for a subtler effect

The changes maintain the visual hierarchy while creating a more space-efficient design across all screen sizes.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/110ca00090e74cad9fa49b1e5068d30e/zen-world)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>110ca00090e74cad9fa49b1e5068d30e</projectId>-->
<!--<branchName>zen-world</branchName>-->